### PR TITLE
SJ-96 스프링 프로파일 적용

### DIFF
--- a/src/main/java/com/example/gimmegonghakauth/InitData.java
+++ b/src/main/java/com/example/gimmegonghakauth/InitData.java
@@ -19,6 +19,7 @@ import com.example.gimmegonghakauth.service.recommend.MajorName;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -27,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@Profile("!(prod || release)")
 public class InitData {
 
     private final MajorsDao majorsDao;

--- a/src/main/java/com/example/gimmegonghakauth/InitFileData.java
+++ b/src/main/java/com/example/gimmegonghakauth/InitFileData.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 @Component
+@Profile("!(prod || release)")
 public class InitFileData {
     private final MajorsDao majorsDao;
     private final CoursesDao coursesDao;


### PR DESCRIPTION
- InitData, InitFileData가 prod 또는 release 프로필 활성화 시 동작하지 않도록 설정
- application.properties에 `spring.profiles.active=<<활성화할 프로필 이름>>`을 추가한다.
- `prod`, `dev`, `release`, `test` 등 각각의 properties 파일을 관리한다.

<img width="269" alt="image" src="https://github.com/Sejong-Java-Study/Gimme-Gonghak-Auth/assets/70999462/fa1ef33a-314b-4aa9-aba1-0692a1edc3de">

<img width="853" alt="image" src="https://github.com/Sejong-Java-Study/Gimme-Gonghak-Auth/assets/70999462/1c0a684c-1896-42d0-bcd0-51296143bc3a">
