### PR TITLE
SJ-100 CICD 워크플로우 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,6 +91,10 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
       - name: AWS ECR에 로그인
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: build/libs 폴더 생성
+        run: |
+          mkdir /build/libs
+
       - name: test_and_build 작업에서 업로드한 빌드 산출물 다운로드
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,7 +95,7 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
         uses: actions/download-artifact@v4
         with:
           name: build-artifact
-          path: ./build
+          path: /build/libs/app.jar
 
       - name: 이미지 빌드 후, ECR에 푸쉬
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,10 +85,7 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
         uses: docker/setup-buildx-action@v3
 
       - name: AWS ECR에 로그인
-        id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v2
-        with:
-          registry-type: public
 
       - name: build/libs 폴더 생성
         run: |
@@ -102,8 +99,8 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
 
       - name: 이미지 빌드 후, ECR에 푸쉬
         env:
-          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
-          REGISTRY_ALIAS: ${{ secrets.REGISTRY_ALIAS }}
+          REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          REGISTRY_ALIAS: ${{ secrets.ECR_REGISTRY_ALIAS }}
           REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
           IMAGE_TAG: latest
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,7 +97,7 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
         uses: actions/download-artifact@v4
         with:
           name: build-artifact
-          path: ./build/libs/app.jar
+          path: ./build/libs/
 
       - name: 빌드 산출물 확인
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,6 +99,10 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
           name: build-artifact
           path: ./build/libs/app.jar
 
+      - name: 빌드 산출물 확인
+        run: |
+          ls -l ./build/libs
+
       - name: 이미지 빌드 후, ECR에 푸쉬
         env:
           REGISTRY: ${{ secrets.ECR_REGISTRY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,8 +85,10 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
         uses: docker/setup-buildx-action@v3
 
       - name: AWS ECR에 로그인
-        id: login-ecr
+        id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
 
       - name: build/libs 폴더 생성
         run: |
@@ -100,13 +102,14 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
 
       - name: 이미지 빌드 후, ECR에 푸쉬
         env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+          REGISTRY_ALIAS: ${{ secrets.REGISTRY_ALIAS }}
           REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
           IMAGE_TAG: latest
         run: |
           docker buildx build --platform=linux/amd64 \
             -f ./docker/Dockerfile_Was_ECR \
-            -t $REGISTRY/$REPOSITORY:$IMAGE_TAG \
+            -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG \
             --push .
 
       - name: 배포 스크립트 폴더 및 파일 추가

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,6 +87,8 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
       - name: AWS ECR에 로그인
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
 
       - name: build/libs 폴더 생성
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ env:
   IMAGE_TAG: latest
 
 jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정의 (like 조건문의 본문)
-  test:
+  test and build:
     name: 스프링부트 프로젝트 테스트 자동화
     runs-on: ubuntu-latest # 상세 작업에 필수적으로 들어가야 하는 항목 : 어느 환경에서 실행되어야 하는지 정의
 
@@ -34,25 +34,30 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
       - name: Gradle 설치
         uses: gradle/actions/setup-gradle@v3
 
-      - name: 러너에 테스트용 MySQL을 설치
-        uses: mirromutth/mysql-action@v1.1
-        with:
-          host port: 3306
-          container port: 3306
-          mysql database: 'jpa_prac'
-          mysql root password: 1234
+#      - name: 러너에 테스트용 MySQL을 설치
+#        uses: mirromutth/mysql-action@v1.1
+#        with:
+#          host port: 3306
+#          container port: 3306
+#          mysql database: 'jpa_prac'
+#          mysql root password: 1234
+#
+#      - name: Test용 Properties 파일 추가
+#        run: |
+#          mkdir -p ./src/test/resources
+#          echo "${{ secrets.TEST_PROPERTIES }}" >> ./src/test/resources/application.properties
 
-      - name: Test용 Properties 파일 추가
+      - name: Main용 Properties 파일 추가
         run: |
-          mkdir -p ./src/test/resources
-          echo "${{ secrets.TEST_PROPERTIES }}" >> ./src/test/resources/application.properties
+          mkdir -p ./src/main/resources
+          echo "${{ secrets.MAIN_PROPERTIES }}" >> ./src/main/resources/application.properties
 
       - name: gradlew 권한 부여
         run: chmod +x ./gradlew
         shell: bash
 
-      - name: 프로젝트 테스트
-        run: ./gradlew test
+#      - name: 프로젝트 테스트
+#        run: ./gradlew test
         
       - name: 프로젝트 빌드
         run: ./gradlew clean bootJar --console=plain

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ env:
   IMAGE_TAG: latest
 
 jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정의 (like 조건문의 본문)
-  test and build:
+  test_and_build:
     name: 스프링부트 프로젝트 테스트 자동화
     runs-on: ubuntu-latest # 상세 작업에 필수적으로 들어가야 하는 항목 : 어느 환경에서 실행되어야 하는지 정의
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,7 +99,7 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
         uses: actions/download-artifact@v4
         with:
           name: build-artifact
-          path: /build/libs/app.jar
+          path: ./build/libs/app.jar
 
       - name: 이미지 빌드 후, ECR에 푸쉬
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,8 +103,10 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
 
       - name: 이미지 빌드 후, ECR에 푸쉬
         run: |
-          docker buildx build --platform=linux/amd64 -f ./docker/Dockerfile_Was_ECR -t ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY}}:${{ env.IMAGE_TAG }} .
-          docker push ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
+          docker buildx build --platform=linux/amd64 \
+            -f ./docker/Dockerfile_Was_ECR \
+            -t ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY}}:${{ env.IMAGE_TAG }} \
+            --push .
 
       - name: 배포 스크립트 폴더 및 파일 추가
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,7 +93,7 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
 
       - name: build/libs 폴더 생성
         run: |
-          mkdir /build/libs
+          mkdir ./build/libs
 
       - name: test_and_build 작업에서 업로드한 빌드 산출물 다운로드
         uses: actions/download-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,8 +87,6 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
       - name: AWS ECR에 로그인
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v2
-        with:
-          registry-type: public
 
       - name: build/libs 폴더 생성
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,8 +64,8 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
           name: build-artifact
           path: build/libs/*.jar
 
-  deploy:
-    name: 스프링부트 프로젝트 배포
+  build_and_push_image:
+    name: 도커 이미지 빌드 및 푸시
     # 가장 최신 버전의 우분투를 러너(Github Actions 실행 환경)로 설정
     runs-on: ubuntu-latest # 상세 작업에 필수적으로 들어가야 하는 항목 : 어느 환경에서 실행되어야 하는지 정의
     needs: test_and_build # test_and_build 작업이 끝난 후에 실행될 수 있도록 설정
@@ -74,18 +74,20 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
       - name: 깃허브 리포지토리 파일 불러오기
         uses: actions/checkout@v4 # 현재 리포지토리로 체크아웃
 
-      - name: Github Actions가 AWS 리소스(ECR, S3, CodeDeploy)에 접근할 수 있도록 인증정보 설정
+      - name: Github Actions가 AWS 리소스(ECR)에 접근할 수 있도록 인증정보 설정, 이 때 리전은 us-east-1
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_PRIVATE_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION_NAME }}
+          aws-region: us-east-1
 
       - name: 멀티 플랫폼 빌드와 캐시 활용을 할 수 있는 도커 빌드X 설치
         uses: docker/setup-buildx-action@v3
 
       - name: AWS ECR에 로그인
         uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
 
       - name: build/libs 폴더 생성
         run: |
@@ -108,6 +110,22 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
             -f ./docker/Dockerfile_Was_ECR \
             -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG \
             --push .
+
+  deploy:
+    name: 스프링부트 프로젝트 배포
+    runs-on: ubuntu-latest
+    needs: build_and_push_image
+
+    steps:
+      - name: 깃허브 리포지토리 파일 불러오기
+        uses: actions/checkout@v4
+
+      - name: Github Actions가 AWS 리소스(S3, CodeDeploy)에 접근할 수 있도록 인증정보 설정
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION_NAME }}
 
       - name: 배포 스크립트 폴더 및 파일 추가
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,7 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
     name: 스프링부트 프로젝트 배포
     # 가장 최신 버전의 우분투를 러너(Github Actions 실행 환경)로 설정
     runs-on: ubuntu-latest # 상세 작업에 필수적으로 들어가야 하는 항목 : 어느 환경에서 실행되어야 하는지 정의
-    needs: test # test 작업이 끝난 후에 실행될 수 있도록 설정
+    needs: test_and_build # test_and_build 작업이 끝난 후에 실행될 수 있도록 설정
     
     steps:
       - name: 깃허브 리포지토리 파일 불러오기
@@ -91,7 +91,7 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
       - name: AWS ECR에 로그인
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: test 작업에서 업로드한 빌드 산출물 다운로드
+      - name: test_and_build 작업에서 업로드한 빌드 산출물 다운로드
         uses: actions/download-artifact@v4
         with:
           name: build-artifact

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,6 @@ env:
   AWS_CODE_DEPLOY_NAME: gonghak98-server # CodeDeploy 애플리케이션 이름
   AWS_CODE_DEPLOY_GROUP: Production # CodeDeploy 배포 그룹 이름
 
-  ECR_REGISTRY: ${{ secrets.ECR_REPOSITORY_ORIGIN }} # login-ecr 스텝의 출력 값(ECR 저장소 이름)
-  ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY_NAME }}
-  IMAGE_TAG: latest
-
 jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정의 (like 조건문의 본문)
   test_and_build:
     name: 스프링부트 프로젝트 테스트 자동화
@@ -89,6 +85,7 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
         uses: docker/setup-buildx-action@v3
 
       - name: AWS ECR에 로그인
+        id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: build/libs 폴더 생성
@@ -102,23 +99,27 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
           path: ./build/libs/app.jar
 
       - name: 이미지 빌드 후, ECR에 푸쉬
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
         run: |
           docker buildx build --platform=linux/amd64 \
             -f ./docker/Dockerfile_Was_ECR \
-            -t ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY}}:${{ env.IMAGE_TAG }} \
+            -t $REGISTRY/$REPOSITORY:$IMAGE_TAG \
             --push .
 
       - name: 배포 스크립트 폴더 및 파일 추가
         run: |
-          mkdir scripts
+          mkdir -p scripts
           echo "${{ secrets.START_SERVER_SH }}" >> ./scripts/start-server.sh
 
       - name: 배포에 필요한 파일 압축하기
-        run: tar -czvf ${{ GITHUB.SHA }}.tar.gz appspec.yml scripts
+        run: tar -czvf ${{ github.sha }}.tar.gz appspec.yml scripts
 
       - name: S3로 배포 압축파일 업로드
         run: |
-          aws s3 cp ./${{ GITHUB.SHA }}.tar.gz s3://${{ env.AWS_S3_BUCKET_NAME }}/${{ GITHUB.SHA }}.tar.gz
+          aws s3 cp ./${{ github.sha }}.tar.gz s3://${{ env.AWS_S3_BUCKET_NAME }}/${{ github.sha }}.tar.gz
 
       - name: CodeDeploy를 활용해 EC2에 프로젝트 코드 배포
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,7 +124,7 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_PRIVATE_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION_NAME }}
 
       - name: 배포 스크립트 폴더 및 파일 추가

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,7 +93,7 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
 
       - name: build/libs 폴더 생성
         run: |
-          mkdir ./build/libs
+          mkdir -p ./build/libs
 
       - name: test_and_build 작업에서 업로드한 빌드 산출물 다운로드
         uses: actions/download-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,7 +102,7 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-          IMAGE_TAG: ${{ github.sha }}
+          IMAGE_TAG: latest
         run: |
           docker buildx build --platform=linux/amd64 \
             -f ./docker/Dockerfile_Was_ECR \

--- a/appspec.yml
+++ b/appspec.yml
@@ -1,5 +1,5 @@
 version: 0.0
-os: Linux
+os: linux
 
 files: # EC2가 배포에 필요한 파일을 가져오는 경로 지정 (CodeDeploy-Agent가 수행함)
   - source: / # S3에 있는 전체파일

--- a/docker/Dockerfile_Was_ECR
+++ b/docker/Dockerfile_Was_ECR
@@ -2,7 +2,7 @@
 FROM amazoncorretto:17-alpine3.19
 
 # Github Actions에서 다운로드한 빌드 산출물을 빌드용 컨테이너에 복사
-COPY build/libs/*.jar /app.jar
+COPY ./build/libs/*.jar app.jar
 
 # 어플리케이션 실행 (/ 루트(절대 경로)에 있는 app.jar 파일을 실행)
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/docker/Dockerfile_Was_ECR
+++ b/docker/Dockerfile_Was_ECR
@@ -2,7 +2,7 @@
 FROM amazoncorretto:17-alpine3.19
 
 # Github Actions에서 다운로드한 빌드 산출물을 빌드용 컨테이너에 복사
-COPY build/libs/*.jar app.jar
+COPY build/libs/*.jar /app.jar
 
 # 어플리케이션 실행 (/ 루트(절대 경로)에 있는 app.jar 파일을 실행)
 ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
## 작업내용
- [x] 빌드에 필요한 main properties 파일 추가
- [x] Public ECR에 접근할 수 있도록 별개의 Job을 추가
  - Public ECR은 us-east-1에서만 접근 가능, 하지만 우리의 AWS 리소스들은 northeast에 있기 때문에 빌드된 이미지를 푸쉬하는 작업과 배포하는 작업을 분리
- [x] CodeDeploy에 필요한 `appspec.yml` 파일의 대소문자 오타 수정
- [x] ECR 전용 이미지 도커파일 추가

## 리뷰 포인트
- CI/CD 관련해서 기존 release 브랜치에서 테스트하던 코드들을 가져와 develop으로 다시 머지한 상황입니다.