### PR TITLE
SJ-109 컨테이너 실행 시, 특정 프로파일이 활성화 되도록 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,10 +43,10 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
 #          mkdir -p ./src/test/resources
 #          echo "${{ secrets.TEST_PROPERTIES }}" >> ./src/test/resources/application.properties
 
-      - name: Main용 Properties 파일 추가
+      - name: 배포용 Properties 파일 추가
         run: |
           mkdir -p ./src/main/resources
-          echo "${{ secrets.MAIN_PROPERTIES }}" >> ./src/main/resources/application.properties
+          echo "${{ secrets.PROD_PROPERTIES }}" >> ./src/main/resources/application-prod.properties
 
       - name: gradlew 권한 부여
         run: chmod +x ./gradlew

--- a/docker/Dockerfile_Was
+++ b/docker/Dockerfile_Was
@@ -23,4 +23,4 @@ FROM amazoncorretto:17-alpine3.19
 COPY --from=build /app/build/libs/*.jar app.jar
 
 # 어플리케이션 실행 (/ 루트(절대 경로)에 있는 app.jar 파일을 실행)
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java","-jar","/app.jar","--spring.profiles.active=release"]

--- a/docker/Dockerfile_Was_ECR
+++ b/docker/Dockerfile_Was_ECR
@@ -5,4 +5,4 @@ FROM amazoncorretto:17-alpine3.19
 COPY ./build/libs/*.jar app.jar
 
 # 어플리케이션 실행 (/ 루트(절대 경로)에 있는 app.jar 파일을 실행)
-ENTRYPOINT ["java","-jar","app.jar"]
+ENTRYPOINT ["java","-jar","app.jar","--spring.profiles.active=prod"]


### PR DESCRIPTION
`InitData`와 `InitFileData`가 `prod`, `release`가 아닌 경우에만 동작하기 때문에 도커 컨테이너 실행 시,
`prod`로 프로파일을 활성화해야 초기 데이터가 DB에 들어가지 않습니다.

이를 위해, 도커 파일에서 `jar`를 실행하는 부분에 특정 프로파일을 활성화하는 커맨드를 추가하였습니다.