### PR TITLE
refactor: StatusController 메서드 분리

### DIFF
--- a/src/main/java/com/example/gimmegonghakauth/controller/StatusController.java
+++ b/src/main/java/com/example/gimmegonghakauth/controller/StatusController.java
@@ -29,12 +29,13 @@ public class StatusController {
     private final RecommendServiceSelectManager recommendServiceSelectManager;
     private final UserDao userDao;
 
-
+    // 사용자의 공학인증 현황과 추천 과목을 가져온다.
     @GetMapping("/status")
-    public String sendStudentId(Authentication authentication, Model model){
+    public String readGonghakStatusResult(Authentication authentication, Model model) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         Long studentId = Long.parseLong(userDetails.getUsername());
 
+        // 컨트롤러가 UserDomain 객체를 가져오는 역할을 수행하고 있음.
         UserDomain student = userDao.findByStudentId(studentId).get();
 
         /*if(student==null){
@@ -43,17 +44,27 @@ public class StatusController {
 
         log.info("studentId= {}",student.getStudentId());
 
-        Map<AbeekTypeConst, ResultPointDto> userResultRatio = gonghakCalculateService
-            .getResultRatio(student).get().getUserResultRatio();
-
-        GonghakRecommendService gonghakRecommendService = recommendServiceSelectManager.selectRecommendService(
-            studentId);
-
-        Map<AbeekTypeConst, List<IncompletedCoursesDto>> recommendCoursesByAbeekType = gonghakRecommendService
-            .createRecommendCourses(student).getRecommendCoursesByAbeekType();
-
-        model.addAttribute("userResultRatio", userResultRatio);
-        model.addAttribute("recommendCoursesByAbeekType", recommendCoursesByAbeekType);
+        readUserResultRatio(model, student);
+        readUserRecommendCourses(model, studentId, student);
         return "gonghak/statusForm";
     }
+
+    // 사용자의 인증 현황 데이터를 가져온다.
+    private void readUserResultRatio(Model model, UserDomain student) {
+        Map<AbeekTypeConst, ResultPointDto> userResultRatio = gonghakCalculateService.getResultRatio(student)
+                                                                                     .get()
+                                                                                     .getUserResultRatio();
+        model.addAttribute("userResultRatio", userResultRatio);
+    }
+
+    // 사용자의 공학인증 추천 과목을 가져온다.
+    private void readUserRecommendCourses(Model model, Long studentId, UserDomain student) {
+        GonghakRecommendService gonghakRecommendService = recommendServiceSelectManager.selectRecommendService(
+            studentId);
+        Map<AbeekTypeConst, List<IncompletedCoursesDto>> recommendCoursesByAbeekType =
+            gonghakRecommendService.createRecommendCourses(student)
+                                   .getRecommendCoursesByAbeekType();
+        model.addAttribute("recommendCoursesByAbeekType", recommendCoursesByAbeekType);
+    }
+
 }


### PR DESCRIPTION
## 문제 정의
현재 `StatusController`의 `sendStudentId()`의 경우, 다음과 같은 로직을 수행하고 있습니다.
- 인증된 사용자의 학번으로 `UserDomain` 객체를 불러온다.
- 인증 현황 데이터를 불러온다.
- 인증 추천 과목을 불러온다.

하지만 `sendStudentId`라는 메서드 이름으로 위에서 언급한 세 가지 로직을 잘 표현하고 있는가?에 대해서 의문이 들었습니다. 따라서 하나의 메서드가 한 가지 일만 할 수 있도록 추상화하는 작업을 하였습니다.

## 변경한 내용
- 기존 `sendStudentId()` 에서 `readGonghakStatusResult()`으로 변경하였습니다. 단순히 학번을 전달하는 것보다 최종적으로 사용자의 인증 현황과 추천과목을 불러오는 것이 주된 로직이라고 판단하였고, 이들을 `GonghakStatusResult`로 표현하였습니다.
- 인증 현황 데이터를 불러오는 로직을 `readUserResultRatio()`로 분리시켰습니다.
- 인증 추천 과목을 불러오는 로직을 `readUserRecommendCourses()`로 분리시켰습니다.

