### PR TITLE
fix: application.properties가 없어서 발생하는 에러 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,7 @@ jobs: # 해당 워크플로우에서 어떤 일이 수행되어야 하는지 정
       - name: 배포용 Properties 파일 추가
         run: |
           mkdir -p ./src/main/resources
+          echo "${{ secrets.MAIN_PROPERTIES }}" >> ./src/main/resources/application.properties
           echo "${{ secrets.PROD_PROPERTIES }}" >> ./src/main/resources/application-prod.properties
 
       - name: gradlew 권한 부여


### PR DESCRIPTION
## 문제 정의
현재 배포 이미지 실행에 사용되는 properties에 submodule 경로를 참조하는 내용이 담겨있어서
ec2에서 설정파일을 읽어오지 못해 실행이 안되고 있습니다.

## 문제 해결
`application.properties`에는 `spring.profiles.active=prod` 옵션을 주어 prod용 properties 파일을 실행하도록 변경하였습니다.