### PR TITLE
feat: 기이수성적 데이터 추가 시, batch insert 적용

### DIFF
--- a/src/main/java/com/example/gimmegonghakauth/dao/CompletedCoursesDao.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/CompletedCoursesDao.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CompletedCoursesDao extends JpaRepository<CompletedCoursesDomain, Long> {
+public interface CompletedCoursesDao
+    extends JpaRepository<CompletedCoursesDomain, Long>, CustomCompletedCoursesDao {
+    
     List<CompletedCoursesDomain> findByUserDomain(UserDomain userDomain);
 }

--- a/src/main/java/com/example/gimmegonghakauth/dao/CustomCompletedCoursesDao.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/CustomCompletedCoursesDao.java
@@ -1,0 +1,11 @@
+package com.example.gimmegonghakauth.dao;
+
+import com.example.gimmegonghakauth.domain.CompletedCoursesDomain;
+import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface CustomCompletedCoursesDao {
+
+    @Transactional
+    void saveAll(List<CompletedCoursesDomain> completedCourses);
+}

--- a/src/main/java/com/example/gimmegonghakauth/dao/CustomCompletedCoursesDaoImpl.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/CustomCompletedCoursesDaoImpl.java
@@ -15,7 +15,7 @@ public class CustomCompletedCoursesDaoImpl implements CustomCompletedCoursesDao 
 
     @Override
     public void saveAll(List<CompletedCoursesDomain> completedCourses) {
-        String sql = "insert into completed_course (semester, user_id, year) values (?,?,?)";
+        String sql = "insert into completed_course (course_id, semester, user_id, year) values (?,?,?,?)";
 
         jdbcTemplate.batchUpdate(
             sql,
@@ -23,9 +23,10 @@ public class CustomCompletedCoursesDaoImpl implements CustomCompletedCoursesDao 
                 @Override
                 public void setValues(PreparedStatement ps, int i) throws SQLException {
                     CompletedCoursesDomain course = completedCourses.get(i);
-                    ps.setString(1,course.getSemester());
-                    ps.setLong(2, course.getUserDomain().getId());
-                    ps.setInt(3,course.getYear());
+                    ps.setLong(1, course.getCoursesDomain().getCourseId());
+                    ps.setString(2, course.getSemester());
+                    ps.setLong(3, course.getUserDomain().getId());
+                    ps.setInt(4, course.getYear());
                 }
 
                 @Override

--- a/src/main/java/com/example/gimmegonghakauth/dao/CustomCompletedCoursesDaoImpl.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/CustomCompletedCoursesDaoImpl.java
@@ -1,0 +1,37 @@
+package com.example.gimmegonghakauth.dao;
+
+import com.example.gimmegonghakauth.domain.CompletedCoursesDomain;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@RequiredArgsConstructor
+public class CustomCompletedCoursesDaoImpl implements CustomCompletedCoursesDao {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void saveAll(List<CompletedCoursesDomain> completedCourses) {
+        String sql = "insert into completed_course (semester, user_id, year) values (?,?,?)";
+
+        jdbcTemplate.batchUpdate(
+            sql,
+            new BatchPreparedStatementSetter() {
+                @Override
+                public void setValues(PreparedStatement ps, int i) throws SQLException {
+                    CompletedCoursesDomain course = completedCourses.get(i);
+                    ps.setString(1,course.getSemester());
+                    ps.setLong(2, course.getUserDomain().getId());
+                    ps.setInt(3,course.getYear());
+                }
+
+                @Override
+                public int getBatchSize() {
+                    return completedCourses.size();
+                }
+            });
+    }
+}


### PR DESCRIPTION
## 🔧연결된 이슈
- closed

## 🛠️작업 내용
- 기이수 과목을 저장하는 save 로직을 JPA가 아닌 JDBC를 사용하도록 변경
- `JdbcTemplate`을 통해 batch insert를 수행하는 saveAll() 인터페이스 및 구현체 추가
- 기존 `CompletedCoursesDao`가 추가된 인터페이스를 상속받도록 수정
- `CompletedCoursesDomain`을 생성한 후, 바로 save를 호출하지 않고 `List`에 담아두었다가 반복문이 끝난 뒤, 한 번에 저장
- 개발용 properties에서 batch insert를 사용할 수 있도록 jdbc url 옵션 추가(서브모듈 변경)

## 🤷‍♂️PR이 필요한 이유
현재 `CompletedCoursesDao`의 구현체는 사용자가 업로드한 기이수 성적파일의 Row 개수만큼 `insert` 쿼리를 생성하고 있습니다.

![image](https://github.com/user-attachments/assets/6d4a147a-2985-49c9-b409-3bfa1ec192bd)
![image](https://github.com/user-attachments/assets/46ca0214-d249-4349-86b5-93ae4af21189)

> extractData가 한 번 호출되었을 때, select 와 insert가 몇 번 호출되는지 로그로 찍어본 결과입니다.

이렇게 될 경우, insert가 호출될 때마다 트랜잭션이 생성되며, 다중 요청이 발생할 경우, 하나의 스레드가 사용하는 커넥션 개수의 증가로 인해 커넥션 고갈 문제가 발생할 수 있다고 생각했습니다.

그래서 `List`에 담아 하나의 insert 쿼리로 처리할 수 있는 batch insert 방식을 추가하였습니다.

### JPA가 아닌 JDBC를 사용한 이유
안타깝게도 영속성 컨텍스트가 관리하는 엔티티의 ID 생성 방식이 `IDENTITY`인 경우, JPA에서 batch insert를 지원하지 않습니다. 엔티티를 1차 캐시에 저장하기 위해서는 DB에서 생성하는 ID가 필요하다 보니 batch insert의 이점을 누릴 수 없어서 지원하지 않는걸로 판단됩니다. 따라서 JDBC를 사용하는 별도의 인터페이스와 구현체를 추가하였으며, 기존에 `CompletedCoursesDao`의 JPA 로직을 사용하는 부분은 변경되지 않았습니다. (save 메서드 제외)

![image](https://github.com/user-attachments/assets/61be79a3-6c87-479a-a55d-02bc18fedb82)

> JPA를 사용했을 때, 여전히 insert 쿼리가 각각 생성되는 모습

![image](https://github.com/user-attachments/assets/5b2db988-289a-4de3-b9b1-6c970487a965)

> JDBC를 사용했을 때, 하나의 insert 쿼리만 생성되는 모습

## 15 VUser 부하테스트 결과

### Load Average(1분당 CPU 부하) 평균 **54% 감소 (2.24 → 1.04)**
<img width="1200" height="580" alt="image" src="https://github.com/user-attachments/assets/b5224723-7cb4-4de4-a0d2-c91829297118" />
<img width="1200" height="597" alt="image" src="https://github.com/user-attachments/assets/45fffe87-14fe-47b6-b258-66e477d5e18e" />

### DB QPS **52% 감소 (862.34QPS → 407.46QPS)**
<img width="2048" height="778" alt="image" src="https://github.com/user-attachments/assets/7f1d802e-81f8-4356-95f8-65fd9091a2a5" />
<img width="2048" height="763" alt="image" src="https://github.com/user-attachments/assets/a2f131e5-aa94-4ced-814a-a42eb5247551" />

### 커넥션 획득 시간이 **89.59% 감소(6.84ms → 0.712ms)**, 사용 시간이 **66.03% 감소(214ms → 72.7ms)**
<img width="2048" height="846" alt="image" src="https://github.com/user-attachments/assets/32dbac31-35aa-4c8c-87c9-edcda1dd27b0" />
<img width="2048" height="853" alt="image" src="https://github.com/user-attachments/assets/fc5af1bc-90d2-455d-add1-a6100cd4dcaa" />
> 개선 전 코드의 경우, 최대 5개의 Pending 스레드가 발생했으나 개선 후에는 Pending 스레드가 존재하지 않음.

## ✔️PR 체크리스트
- [ ] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [x] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
