### PR TITLE
refactor: GonghakCalculateService.stackCredit

### DIFF
--- a/src/main/java/com/example/gimmegonghakauth/status/service/GonghakCalculateService.java
+++ b/src/main/java/com/example/gimmegonghakauth/status/service/GonghakCalculateService.java
@@ -89,8 +89,6 @@ public class GonghakCalculateService {
                 return AbeekTypeConst.MAJOR;
             case "전문교양":
                 return AbeekTypeConst.PROFESSIONAL_NON_MAJOR;
-            case "교양":
-                return AbeekTypeConst.NON_MAJOR;
             case "MSC":
                 return AbeekTypeConst.MSC;
             case "BSM":
@@ -103,8 +101,15 @@ public class GonghakCalculateService {
 
     private void stackCredit(AbeekTypeConst abeekTypeConst, CourseDetailsDto courseDetailsDto,
         Map<AbeekTypeConst, AbeekDetailsDto> userResult) {
+
+        if (userResult.containsKey(AbeekTypeConst.NON_MAJOR)
+            && abeekTypeConst == AbeekTypeConst.PROFESSIONAL_NON_MAJOR) {
+            abeekTypeConst = AbeekTypeConst.NON_MAJOR;
+        }
+
         double inputCredit = getInputCredit(abeekTypeConst, courseDetailsDto);
         AbeekDetailsDto currentDetails = userResult.get(abeekTypeConst);
+
         if (currentDetails != null) {
             ResultPointDto currentResultPoint = currentDetails.getResultPoint();
             double newUserPoint = currentResultPoint.getUserPoint() + inputCredit;

--- a/src/main/java/com/example/gimmegonghakauth/status/service/GonghakCalculateService.java
+++ b/src/main/java/com/example/gimmegonghakauth/status/service/GonghakCalculateService.java
@@ -132,6 +132,11 @@ public class GonghakCalculateService {
             return;
         }
 
+        if (userAbeekCredit.containsKey(AbeekTypeConst.NON_MAJOR)
+            && abeekTypeConst == AbeekTypeConst.PROFESSIONAL_NON_MAJOR) {
+            abeekTypeConst = AbeekTypeConst.NON_MAJOR;
+        }
+
         AbeekDetailsDto currentDetails = userAbeekCredit.get(abeekTypeConst);
         if (currentDetails != null) {
             List<CourseDetailsDto> updatedCourses = currentDetails.getCoursesDetails();


### PR DESCRIPTION
## 🔧연결된 이슈
- closed

## 🛠️작업 내용
- `AbeekTypeConst` 가 **NON_MAJOR** (교양) 인 경우 학점이 제대로 계산되지 않는 버그 수정

![image](https://github.com/user-attachments/assets/8a336b3e-e63f-418c-8804-debe84be5fea)
 
## 🤷‍♂️PR이 필요한 이유
https://github.com/Sejong-Java-Study/gonghak98/pull/42 를 통해 **'전문 교양'** 에서 **'교양'** 으로 바뀐 항목들에 대해 리팩토링을 실시했습니다.
그러나 현재 `gonghakCourse` 테이블에 삽입된 데이터를 살펴보면 `course_category_const` 이 **'전문 교양'** 하나로 통일되어 있습니다. 이는 데이터 정제 과정에서 발생한 오류인듯 합니다.

이에 반해 `abeek` 테이블의 기준은 원래와 같이 **'전문 교양'** 또는 **'교양'** 으로 구분되어있기 때문에, user status 계산 과정에서 사용자의 abeek 기준은 '교양' 일 경우 `gonghakCourse`에서는 **'전문 교양'** 으로만 처리하므로 위 버그와 같이 0점으로 처리되었습니다.

그래서 원래는 DB에 삽입된 전체 데이터를 손봐야하는것이 맞으나 우선은 계산 과정에서 사용자의 abeek기준이 '교양' 인 경우 읽어온 course의 abeekType을 '교양' 으로 바꾸어 로직을 처리하는 방식으로 해결하였습니다.

로컬에서 확인해보았을때, 데사, 컴공, 전전통, 소웨 모두 정상작동 확인하였으나 **소프트웨어 학과에서 18,19년도 '세계사: 인간과 문명' 과목이 누락**된것을 확인하여 추가하겠습니다.

로컬에서도 한번 확인 부탁드립니다.

++ 추가적으로 데이터사이언스학과 수치해석(4102), 대학생활과 진로설계(10351) 과목도 누락되었습니다.


## ✔️PR 체크리스트
- [ ] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [ ] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
