### PR TITLE
feat: MyAbeekService 구현

### DIFF
--- a/src/main/java/com/example/gimmegonghakauth/common/constant/AbeekTypeConst.java
+++ b/src/main/java/com/example/gimmegonghakauth/common/constant/AbeekTypeConst.java
@@ -16,6 +16,21 @@ public enum AbeekTypeConst {
         this.typeMessage = typeMessage;
     }
 
+    public static AbeekTypeConst getCourseCategoryType(String courseCategory) {
+        switch (courseCategory) {
+            case "전공":
+                return AbeekTypeConst.MAJOR;
+            case "전문교양":
+                return AbeekTypeConst.PROFESSIONAL_NON_MAJOR;
+            case "MSC":
+                return AbeekTypeConst.MSC;
+            case "BSM":
+                return AbeekTypeConst.BSM;
+            default:
+                return null;
+        }
+    }
+
     public String getTypeMessage() {
         return typeMessage;
     }

--- a/src/main/java/com/example/gimmegonghakauth/status/controller/StatusController.java
+++ b/src/main/java/com/example/gimmegonghakauth/status/controller/StatusController.java
@@ -1,6 +1,7 @@
 package com.example.gimmegonghakauth.status.controller;
 
 import com.example.gimmegonghakauth.common.constant.AbeekTypeConst;
+import com.example.gimmegonghakauth.status.service.MyAbeekService;
 import com.example.gimmegonghakauth.status.service.dto.AbeekDetailsDto;
 import com.example.gimmegonghakauth.status.service.dto.CourseDetailsDto;
 import com.example.gimmegonghakauth.status.service.dto.GonghakResultDto;
@@ -29,7 +30,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequiredArgsConstructor
 public class StatusController {
 
-    private final GonghakCalculateService gonghakCalculateService;
+    //private final GonghakCalculateService gonghakCalculateService;
+    private final MyAbeekService myAbeekService;
     private final RecommendServiceSelectManager recommendServiceSelectManager;
     private final UserRepository userRepository;
 
@@ -49,8 +51,8 @@ public class StatusController {
 
     // 사용자의 인증 현황 데이터를 가져온다.
     private void readUserResult(Model model, UserDomain student) {
-        GonghakResultDto userResultRatio = gonghakCalculateService.getResult(
-                student)
+        GonghakResultDto userResultRatio = myAbeekService.getResult(
+                student.getStudentId())
             .orElseThrow(IllegalArgumentException::new);
         addResultPoint(model, userResultRatio);
         addCoursesDetails(model, userResultRatio);

--- a/src/main/java/com/example/gimmegonghakauth/status/controller/StatusController.java
+++ b/src/main/java/com/example/gimmegonghakauth/status/controller/StatusController.java
@@ -44,15 +44,15 @@ public class StatusController {
         // 컨트롤러가 UserDomain 객체를 가져오는 역할을 수행하고 있음.
         UserDomain student = userRepository.findByStudentId(studentId).get();
 
-        readUserResult(model, student);
+        readUserResult(model, studentId);
         readUserRecommendCourses(model, studentId, student);
         return "gonghak/statusForm";
     }
 
     // 사용자의 인증 현황 데이터를 가져온다.
-    private void readUserResult(Model model, UserDomain student) {
+    private void readUserResult(Model model, Long studentId) {
         GonghakResultDto userResultRatio = myAbeekService.getResult(
-                student.getStudentId())
+                studentId)
             .orElseThrow(IllegalArgumentException::new);
         addResultPoint(model, userResultRatio);
         addCoursesDetails(model, userResultRatio);

--- a/src/main/java/com/example/gimmegonghakauth/status/domain/Abeek.java
+++ b/src/main/java/com/example/gimmegonghakauth/status/domain/Abeek.java
@@ -1,0 +1,126 @@
+package com.example.gimmegonghakauth.status.domain;
+
+import com.example.gimmegonghakauth.common.constant.AbeekTypeConst;
+import com.example.gimmegonghakauth.status.service.dto.AbeekDetailsDto;
+import com.example.gimmegonghakauth.status.service.dto.CourseDetailsDto;
+import com.example.gimmegonghakauth.status.service.dto.GonghakResultDto;
+import com.example.gimmegonghakauth.status.service.dto.GonghakStandardDto;
+import com.example.gimmegonghakauth.status.service.dto.ResultPointDto;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class Abeek {
+
+    private final Map<AbeekTypeConst, Integer> standards;
+
+    public Abeek(GonghakStandardDto gonghakStandardDto) {
+        this.standards = gonghakStandardDto.getStandards();
+    }
+
+    public Optional<GonghakResultDto> getResult(List<CourseDetailsDto> userCompletedCourses) {
+        // default user abeek 학점 상태 map
+        Map<AbeekTypeConst, AbeekDetailsDto> userResult = getUserAbeekCreditDefault(
+            standards);
+
+        // stackUserGonghakCredit -> abeekType에 맞게 이수한 총 학점을 계산한다.
+        stackUserGonghakCredit(userCompletedCourses,
+            userResult);
+
+        // 인증 상태(비율) return
+        return Optional.of(new GonghakResultDto(userResult));
+    }
+
+    private Map<AbeekTypeConst, AbeekDetailsDto> getUserAbeekCreditDefault(
+        Map<AbeekTypeConst, Integer> standards) {
+        Map<AbeekTypeConst, AbeekDetailsDto> userAbeekCredit = new ConcurrentHashMap<>();
+        Arrays.stream(AbeekTypeConst.values()).forEach(abeekTypeConst -> {
+            if (standards.containsKey(abeekTypeConst)) {
+                ResultPointDto resultPoint = new ResultPointDto(0.0, standards.get(abeekTypeConst));
+                AbeekDetailsDto abeekDetailsDto = new AbeekDetailsDto(resultPoint,
+                    new ArrayList<>());
+                userAbeekCredit.put(abeekTypeConst, abeekDetailsDto);
+            }
+        });
+        return userAbeekCredit;
+    }
+
+    // abeekType에 맞게 이수한 총 학점을 계산한다.
+    private void stackUserGonghakCredit(List<CourseDetailsDto> userCoursesByMajor,
+        Map<AbeekTypeConst, AbeekDetailsDto> userResult) {
+        userCoursesByMajor.forEach(courseDetailsDto -> {
+            AbeekTypeConst typeConst = getCourseCategoryType(
+                String.valueOf(courseDetailsDto.getCourseCategory()));
+            if (typeConst != null) {
+                stackCredit(typeConst, courseDetailsDto, userResult);
+                addCourseToDetails(typeConst, courseDetailsDto, userResult);
+            }
+            stackCredit(AbeekTypeConst.DESIGN, courseDetailsDto, userResult);
+            addCourseToDetails(AbeekTypeConst.DESIGN, courseDetailsDto, userResult);
+            stackCredit(AbeekTypeConst.MINIMUM_CERTI, courseDetailsDto, userResult);
+            addCourseToDetails(AbeekTypeConst.MINIMUM_CERTI, courseDetailsDto, userResult);
+        });
+    }
+
+    private AbeekTypeConst getCourseCategoryType(String courseCategory) {
+        switch (courseCategory) {
+            case "전공":
+                return AbeekTypeConst.MAJOR;
+            case "전문교양":
+                return AbeekTypeConst.PROFESSIONAL_NON_MAJOR;
+            case "MSC":
+                return AbeekTypeConst.MSC;
+            case "BSM":
+                return AbeekTypeConst.BSM;
+            default:
+                return null;
+        }
+    }
+
+    private void stackCredit(AbeekTypeConst abeekTypeConst, CourseDetailsDto courseDetailsDto,
+        Map<AbeekTypeConst, AbeekDetailsDto> userResult) {
+
+        if (userResult.containsKey(AbeekTypeConst.NON_MAJOR)
+            && abeekTypeConst == AbeekTypeConst.PROFESSIONAL_NON_MAJOR) {
+            abeekTypeConst = AbeekTypeConst.NON_MAJOR;
+        }
+
+        double inputCredit = getInputCredit(abeekTypeConst, courseDetailsDto);
+        AbeekDetailsDto currentDetails = userResult.get(abeekTypeConst);
+
+        if (currentDetails != null) {
+            ResultPointDto currentResultPoint = currentDetails.getResultPoint();
+            double newUserPoint = currentResultPoint.getUserPoint() + inputCredit;
+
+            currentResultPoint.setUserPoint(newUserPoint);
+        }
+    }
+
+    private double getInputCredit(AbeekTypeConst abeekTypeConst,
+        CourseDetailsDto courseDetailsDto) {
+        return (abeekTypeConst == AbeekTypeConst.DESIGN) ? courseDetailsDto.getDesignCredit()
+            : (double) courseDetailsDto.getCredit();
+    }
+
+    private void addCourseToDetails(AbeekTypeConst abeekTypeConst,
+        CourseDetailsDto courseDetailsDto,
+        Map<AbeekTypeConst, AbeekDetailsDto> userAbeekCredit) {
+        if (getInputCredit(abeekTypeConst, courseDetailsDto) == 0) {
+            return;
+        }
+
+        if (userAbeekCredit.containsKey(AbeekTypeConst.NON_MAJOR)
+            && abeekTypeConst == AbeekTypeConst.PROFESSIONAL_NON_MAJOR) {
+            abeekTypeConst = AbeekTypeConst.NON_MAJOR;
+        }
+
+        AbeekDetailsDto currentDetails = userAbeekCredit.get(abeekTypeConst);
+        if (currentDetails != null) {
+            List<CourseDetailsDto> updatedCourses = currentDetails.getCoursesDetails();
+            updatedCourses.add(courseDetailsDto);
+        }
+    }
+}

--- a/src/main/java/com/example/gimmegonghakauth/status/domain/Abeek.java
+++ b/src/main/java/com/example/gimmegonghakauth/status/domain/Abeek.java
@@ -32,14 +32,12 @@ public class Abeek {
         return Optional.of(new GonghakResultDto(userResult));
     }
 
-    private Map<AbeekTypeConst, AbeekDetailsDto> getUserAbeekCreditDefault(
-        Map<AbeekTypeConst, Integer> standards) {
+    private Map<AbeekTypeConst, AbeekDetailsDto> getUserAbeekCreditDefault(Map<AbeekTypeConst, Integer> standards) {
         Map<AbeekTypeConst, AbeekDetailsDto> userAbeekCredit = new ConcurrentHashMap<>();
         Arrays.stream(AbeekTypeConst.values()).forEach(abeekTypeConst -> {
             if (standards.containsKey(abeekTypeConst)) {
                 ResultPointDto resultPoint = new ResultPointDto(0.0, standards.get(abeekTypeConst));
-                AbeekDetailsDto abeekDetailsDto = new AbeekDetailsDto(resultPoint,
-                    new ArrayList<>());
+                AbeekDetailsDto abeekDetailsDto = new AbeekDetailsDto(resultPoint, new ArrayList<>());
                 userAbeekCredit.put(abeekTypeConst, abeekDetailsDto);
             }
         });
@@ -50,7 +48,7 @@ public class Abeek {
     private void stackUserGonghakCredit(List<CourseDetailsDto> userCoursesByMajor,
         Map<AbeekTypeConst, AbeekDetailsDto> userResult) {
         userCoursesByMajor.forEach(courseDetailsDto -> {
-            AbeekTypeConst typeConst = getCourseCategoryType(
+            AbeekTypeConst typeConst = AbeekTypeConst.getCourseCategoryType(
                 String.valueOf(courseDetailsDto.getCourseCategory()));
             if (typeConst != null) {
                 stackCredit(typeConst, courseDetailsDto, userResult);
@@ -61,21 +59,6 @@ public class Abeek {
             stackCredit(AbeekTypeConst.MINIMUM_CERTI, courseDetailsDto, userResult);
             addCourseToDetails(AbeekTypeConst.MINIMUM_CERTI, courseDetailsDto, userResult);
         });
-    }
-
-    private AbeekTypeConst getCourseCategoryType(String courseCategory) {
-        switch (courseCategory) {
-            case "전공":
-                return AbeekTypeConst.MAJOR;
-            case "전문교양":
-                return AbeekTypeConst.PROFESSIONAL_NON_MAJOR;
-            case "MSC":
-                return AbeekTypeConst.MSC;
-            case "BSM":
-                return AbeekTypeConst.BSM;
-            default:
-                return null;
-        }
     }
 
     private void stackCredit(AbeekTypeConst abeekTypeConst, CourseDetailsDto courseDetailsDto,
@@ -97,14 +80,13 @@ public class Abeek {
         }
     }
 
-    private double getInputCredit(AbeekTypeConst abeekTypeConst,
-        CourseDetailsDto courseDetailsDto) {
+    private double getInputCredit(AbeekTypeConst abeekTypeConst, CourseDetailsDto courseDetailsDto) {
         return (abeekTypeConst == AbeekTypeConst.DESIGN) ? courseDetailsDto.getDesignCredit()
             : (double) courseDetailsDto.getCredit();
     }
 
-    private void addCourseToDetails(AbeekTypeConst abeekTypeConst,
-        CourseDetailsDto courseDetailsDto, Map<AbeekTypeConst, AbeekDetailsDto> userAbeekCredit) {
+    private void addCourseToDetails(AbeekTypeConst abeekTypeConst, CourseDetailsDto courseDetailsDto,
+        Map<AbeekTypeConst, AbeekDetailsDto> userAbeekCredit) {
         if (getInputCredit(abeekTypeConst, courseDetailsDto) == 0) {
             return;
         }

--- a/src/main/java/com/example/gimmegonghakauth/status/domain/Abeek.java
+++ b/src/main/java/com/example/gimmegonghakauth/status/domain/Abeek.java
@@ -23,12 +23,10 @@ public class Abeek {
 
     public Optional<GonghakResultDto> getResult(List<CourseDetailsDto> userCompletedCourses) {
         // default user abeek 학점 상태 map
-        Map<AbeekTypeConst, AbeekDetailsDto> userResult = getUserAbeekCreditDefault(
-            standards);
+        Map<AbeekTypeConst, AbeekDetailsDto> userResult = getUserAbeekCreditDefault(standards);
 
         // stackUserGonghakCredit -> abeekType에 맞게 이수한 총 학점을 계산한다.
-        stackUserGonghakCredit(userCompletedCourses,
-            userResult);
+        stackUserGonghakCredit(userCompletedCourses, userResult);
 
         // 인증 상태(비율) return
         return Optional.of(new GonghakResultDto(userResult));
@@ -106,8 +104,7 @@ public class Abeek {
     }
 
     private void addCourseToDetails(AbeekTypeConst abeekTypeConst,
-        CourseDetailsDto courseDetailsDto,
-        Map<AbeekTypeConst, AbeekDetailsDto> userAbeekCredit) {
+        CourseDetailsDto courseDetailsDto, Map<AbeekTypeConst, AbeekDetailsDto> userAbeekCredit) {
         if (getInputCredit(abeekTypeConst, courseDetailsDto) == 0) {
             return;
         }

--- a/src/main/java/com/example/gimmegonghakauth/status/infrastructure/AbeekRepository.java
+++ b/src/main/java/com/example/gimmegonghakauth/status/infrastructure/AbeekRepository.java
@@ -1,0 +1,12 @@
+package com.example.gimmegonghakauth.status.infrastructure;
+
+import com.example.gimmegonghakauth.common.domain.MajorsDomain;
+import com.example.gimmegonghakauth.status.domain.AbeekDomain;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AbeekRepository extends JpaRepository<AbeekDomain, Long> {
+    AbeekDomain save(AbeekDomain abeekDomain);
+    List<AbeekDomain> findAllByYearAndMajorsDomain(int year, MajorsDomain majorsDomain);
+
+}

--- a/src/main/java/com/example/gimmegonghakauth/status/infrastructure/GonghakCoursesRepository.java
+++ b/src/main/java/com/example/gimmegonghakauth/status/infrastructure/GonghakCoursesRepository.java
@@ -1,0 +1,29 @@
+package com.example.gimmegonghakauth.status.infrastructure;
+
+import com.example.gimmegonghakauth.common.constant.CourseCategoryConst;
+import com.example.gimmegonghakauth.common.domain.MajorsDomain;
+import com.example.gimmegonghakauth.status.domain.GonghakCoursesDomain;
+import com.example.gimmegonghakauth.status.service.dto.CourseDetailsDto;
+import com.example.gimmegonghakauth.status.service.dto.IncompletedCoursesDto;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GonghakCoursesRepository extends JpaRepository<GonghakCoursesDomain,Long> {
+
+    @Query("select new com.example.gimmegonghakauth.status.service.dto.CourseDetailsDto(GCD.coursesDomain.courseId, GCD.coursesDomain.name, CCD.year, CCD.semester, GCD.courseCategory, GCD.passCategory, GCD.designCredit, GCD.coursesDomain.credit) from GonghakCoursesDomain GCD "
+        + "join CompletedCoursesDomain CCD on GCD.coursesDomain = CCD.coursesDomain "
+        + "where CCD.userDomain.studentId =:studentId and GCD.majorsDomain.id = :majorsId and GCD.year = :year")
+    List<CourseDetailsDto> findUserCompletedCourses(@Param("studentId") Long studentId, @Param("majorsId") Long majorId, @Param("year") Long year);
+
+    @Query("select new com.example.gimmegonghakauth.status.service.dto.IncompletedCoursesDto(GCD.coursesDomain.name, GCD.courseCategory, GCD.coursesDomain.credit, GCD.designCredit) from GonghakCoursesDomain GCD  "
+        + "left join CompletedCoursesDomain CCD on CCD.coursesDomain = GCD.coursesDomain "
+        + "where GCD.majorsDomain = :majorsDomain and GCD.year = :year and GCD.courseCategory = :courseCategory and CCD.id is null and :studentId is not null")
+    List<IncompletedCoursesDto> findUserIncompletedCourses(@Param("courseCategory") CourseCategoryConst courseCategory, @Param("studentId") Long studentId, @Param("majorsDomain") MajorsDomain majorsDomain, @Param("year") Long year);
+
+}
+
+

--- a/src/main/java/com/example/gimmegonghakauth/status/service/AbeekService.java
+++ b/src/main/java/com/example/gimmegonghakauth/status/service/AbeekService.java
@@ -1,25 +1,43 @@
 package com.example.gimmegonghakauth.status.service;
 
+import com.example.gimmegonghakauth.common.constant.AbeekTypeConst;
 import com.example.gimmegonghakauth.common.domain.MajorsDomain;
+import com.example.gimmegonghakauth.status.domain.AbeekDomain;
+import com.example.gimmegonghakauth.status.infrastructure.AbeekRepository;
 import com.example.gimmegonghakauth.status.infrastructure.GonghakRepository;
 import com.example.gimmegonghakauth.status.service.dto.CourseDetailsDto;
 import com.example.gimmegonghakauth.status.service.dto.GonghakStandardDto;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class AbeekService {
+    private static final int LATEST_YEAR = 24;
 
-    private final GonghakRepository gonghakRepository;
-
-    public Optional<GonghakStandardDto> getStandard(MajorsDomain majorsDomain) {
-        return gonghakRepository.findStandard(majorsDomain);
+    private final AbeekRepository abeekRepository;
+    public Optional<GonghakStandardDto> findStandard(MajorsDomain majorsDomain){
+        return changeToGonghakStandardDto(majorsDomain, LATEST_YEAR);
     }
 
-    public List<CourseDetailsDto> findUserCompletedCourses(Long studentId, MajorsDomain majorsDomain){
-        return gonghakRepository.findUserCompletedCourses(studentId,majorsDomain);
+    private Optional<GonghakStandardDto> changeToGonghakStandardDto(MajorsDomain majorsDomain, int year) {
+
+        Map<AbeekTypeConst, Integer> standards = new ConcurrentHashMap<>();
+        // year, major를 기준으로 abeek 데이터를 불러온다.
+        List<AbeekDomain> allByYearAndMajorsDomain = abeekRepository.findAllByYearAndMajorsDomain(year, majorsDomain);
+
+        // abeek을 기반으로 abeekType(영역별 구분),minCredit(영역별 인증학점) 저장한다.
+        allByYearAndMajorsDomain.forEach(
+            abeekDomain -> {
+                standards.put(abeekDomain.getAbeekType(),abeekDomain.getMinCredit());
+            }
+        );
+
+        return Optional.of(new GonghakStandardDto(standards));
     }
+
 }

--- a/src/main/java/com/example/gimmegonghakauth/status/service/AbeekService.java
+++ b/src/main/java/com/example/gimmegonghakauth/status/service/AbeekService.java
@@ -1,0 +1,25 @@
+package com.example.gimmegonghakauth.status.service;
+
+import com.example.gimmegonghakauth.common.domain.MajorsDomain;
+import com.example.gimmegonghakauth.status.infrastructure.GonghakRepository;
+import com.example.gimmegonghakauth.status.service.dto.CourseDetailsDto;
+import com.example.gimmegonghakauth.status.service.dto.GonghakStandardDto;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AbeekService {
+
+    private final GonghakRepository gonghakRepository;
+
+    public Optional<GonghakStandardDto> getStandard(MajorsDomain majorsDomain) {
+        return gonghakRepository.findStandard(majorsDomain);
+    }
+
+    public List<CourseDetailsDto> findUserCompletedCourses(Long studentId, MajorsDomain majorsDomain){
+        return gonghakRepository.findUserCompletedCourses(studentId,majorsDomain);
+    }
+}

--- a/src/main/java/com/example/gimmegonghakauth/status/service/GonghakCoursesService.java
+++ b/src/main/java/com/example/gimmegonghakauth/status/service/GonghakCoursesService.java
@@ -1,0 +1,32 @@
+package com.example.gimmegonghakauth.status.service;
+
+import com.example.gimmegonghakauth.common.constant.CourseCategoryConst;
+import com.example.gimmegonghakauth.common.domain.MajorsDomain;
+import com.example.gimmegonghakauth.status.infrastructure.GonghakCoursesRepository;
+import com.example.gimmegonghakauth.status.service.dto.CourseDetailsDto;
+import com.example.gimmegonghakauth.status.service.dto.IncompletedCoursesDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GonghakCoursesService {
+
+    private static final int DIVIDER = 1000000;
+
+    private final GonghakCoursesRepository gonghakCoursesRepository;
+
+    public List<CourseDetailsDto> findUserCompletedCourses(
+        Long studentId, MajorsDomain majorsDomain) {
+        return gonghakCoursesRepository.findUserCompletedCourses(studentId, majorsDomain.getId(),
+            studentId / DIVIDER);
+    }
+
+    // gonghakCourse 중 이수하지 않은 과목을 불러온다.
+    public List<IncompletedCoursesDto> findUserIncompletedCourses(
+        CourseCategoryConst courseCategory, Long studentId, MajorsDomain majorsDomain) {
+        return gonghakCoursesRepository.findUserIncompletedCourses(courseCategory, studentId,
+            majorsDomain, studentId / DIVIDER);
+    }
+}

--- a/src/main/java/com/example/gimmegonghakauth/status/service/MyAbeekService.java
+++ b/src/main/java/com/example/gimmegonghakauth/status/service/MyAbeekService.java
@@ -2,6 +2,7 @@ package com.example.gimmegonghakauth.status.service;
 
 import com.example.gimmegonghakauth.common.domain.MajorsDomain;
 import com.example.gimmegonghakauth.status.domain.Abeek;
+import com.example.gimmegonghakauth.status.infrastructure.GonghakCoursesRepository;
 import com.example.gimmegonghakauth.status.service.dto.CourseDetailsDto;
 import com.example.gimmegonghakauth.status.service.dto.GonghakResultDto;
 import com.example.gimmegonghakauth.status.service.dto.GonghakStandardDto;
@@ -18,17 +19,17 @@ public class MyAbeekService {
 
     private final UserService userService;
     private final AbeekService abeekService;
+    private final GonghakCoursesService gonghakCoursesService;
 
     public Optional<GonghakResultDto> getResult(Long studentId) {
         UserDomain user = userService.getByStudentId(studentId);
         MajorsDomain major = user.getMajorsDomain();
 
         // Abeek 기준
-        GonghakStandardDto gonghakStandardDto = abeekService.getStandard(major).get();
+        GonghakStandardDto gonghakStandardDto = abeekService.findStandard(major).get();
 
         // 이수한 공학인증 과목
-        List<CourseDetailsDto> completedCourse = abeekService.findUserCompletedCourses(studentId,
-            major);
+        List<CourseDetailsDto> completedCourse = gonghakCoursesService.findUserCompletedCourses(studentId, major);
 
         // 결과 반환
         Abeek abeek = new Abeek(gonghakStandardDto);

--- a/src/main/java/com/example/gimmegonghakauth/status/service/MyAbeekService.java
+++ b/src/main/java/com/example/gimmegonghakauth/status/service/MyAbeekService.java
@@ -1,0 +1,38 @@
+package com.example.gimmegonghakauth.status.service;
+
+import com.example.gimmegonghakauth.common.domain.MajorsDomain;
+import com.example.gimmegonghakauth.status.domain.Abeek;
+import com.example.gimmegonghakauth.status.service.dto.CourseDetailsDto;
+import com.example.gimmegonghakauth.status.service.dto.GonghakResultDto;
+import com.example.gimmegonghakauth.status.service.dto.GonghakStandardDto;
+import com.example.gimmegonghakauth.user.domain.UserDomain;
+import com.example.gimmegonghakauth.user.service.UserService;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MyAbeekService {
+
+    private final UserService userService;
+    private final AbeekService abeekService;
+
+    public Optional<GonghakResultDto> getResult(Long studentId) {
+        UserDomain user = userService.getByStudentId(studentId);
+        MajorsDomain major = user.getMajorsDomain();
+
+        // Abeek 기준
+        GonghakStandardDto gonghakStandardDto = abeekService.getStandard(major).get();
+
+        // 이수한 공학인증 과목
+        List<CourseDetailsDto> completedCourse = abeekService.findUserCompletedCourses(studentId,
+            major);
+
+        // 결과 반환
+        Abeek abeek = new Abeek(gonghakStandardDto);
+        return abeek.getResult(completedCourse);
+    }
+
+}


### PR DESCRIPTION
## 🔧연결된 이슈
- closed

## 🛠️작업 내용
- 기존 `GonghakCalculatorService` 의 책임을 `UserService`, `AbeekService`, `GonghakCoursesService` 로 분리함
- 기존 `GonghakRepository`가 가지고 있던 책임을 `AbeekRepository` 와 `GonghakCoursesRepository` 로 분리 후, **Dao**가 가지고 있던 불필요한 **비지니스 로직을 Service Layer** 로 옮김

## 🤷‍♂️PR이 필요한 이유
- SRP 준수

### 이전 구조
![image](https://github.com/user-attachments/assets/16c7045d-e302-4c0f-877b-6598c357979b)
### 바뀐 구조
![image](https://github.com/user-attachments/assets/2088737c-e10b-46da-9bb1-ca856e75bd7d)

`AbeekService`가 이수정보를 조회하는 방식은 아래의 순서를 따릅니다.

1. `UserService` 로 부터 **User** 객체를 받아온다.
2. 'AbeekService`로 부터 **AbeekStandard**를 받아온다.
3. 'GonghakCoursesService`로 부터 **이수한 공학인증 과목**을 받아온다.
4. `Abeek` 객체를 생성 후 **이수 진행사항**을 계산하도록 한다.

+ 위 방식대로라면 기존의 `AbeekDao`, `GonghakCoursesDao`, `GonghakDao`, `GonghakRepository` 는 삭제되어야 하지만, 이후 리팩토링할 추천 메서드와도 관련있고, 테스트 코드와도 복잡하게 얽혀있어 일단 잠정적으로 삭제를 보류해두었습니다.

## ✔️PR 체크리스트
- [ ] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [ ] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
